### PR TITLE
chore: Remove Google Analytics

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -136,10 +136,6 @@ const config: Config = {
         theme: {
           customCss: "./src/css/custom.css",
         },
-        gtag: {
-          trackingID: "G-1FVDBFPGXN",
-          anonymizeIP: true,
-        },
       } satisfies Preset.Options,
     ],
   ],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.0.1",
-    "@docusaurus/plugin-google-gtag": "^3.0.1",
     "@docusaurus/preset-classic": "^3.0.1",
     "@docusaurus/theme-classic": "^3.0.1",
     "@heroicons/react": "^2.0.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ dependencies:
   '@docusaurus/core':
     specifier: ^3.0.1
     version: 3.0.1(@docusaurus/types@3.0.1)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
-  '@docusaurus/plugin-google-gtag':
-    specifier: ^3.0.1
-    version: 3.0.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
   '@docusaurus/preset-classic':
     specifier: ^3.0.1
     version: 3.0.1(@algolia/client-search@4.20.0)(@types/react@18.2.42)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.11.0)(typescript@5.2.2)

--- a/src/common/analytics.ts
+++ b/src/common/analytics.ts
@@ -1,30 +1,19 @@
 import type { PostHog } from 'posthog-js';
 
-type GTagFunction = (
-  command: 'config' | 'event' | 'set', 
-  eventNameOrConfigId: string, 
-  params?: GTagEventProps | { [key: string]: any }
-) => void;
-
 // Extend the Window interface
 declare global {
   interface Window {
-    gtag: GTagFunction;
     posthog: PostHog;
   }
 }
 
-
-type GTagEventProps = {
+type EventProps = {
   category?: string;
   errorMessage?: String;
   success?: boolean;
 };
 
-export const recordEvent = (eventName: string, props?: GTagEventProps) => {
-  if (typeof window !== 'undefined' && window.gtag) {
-    window.gtag('event', eventName, props);
-  }
+export const recordEvent = (eventName: string, props?: EventProps) => {
   if (typeof window !== 'undefined' && window.posthog) {
     window.posthog.capture(eventName, props);
   }


### PR DESCRIPTION
We have fully migrated to PostHog now, which is GDPR-compliant and more privacy-focused.