### PR TITLE
chore: Add a redirect for `/docs`

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -146,6 +146,10 @@ const config: Config = {
             to: "https://discord.gg/KtMAfSDXGQ",
             from: "/discord",
           },
+          {
+            to: '/docs/overview',
+            from: '/docs',
+          }
         ],
       },
     ],


### PR DESCRIPTION
Redirects `/docs` to the Overview page.