### PR TITLE
ci: Prevent concurrent deploys

### DIFF
--- a/.github/workflows/deploy_preview.yaml
+++ b/.github/workflows/deploy_preview.yaml
@@ -7,6 +7,11 @@ permissions:
   contents: read
   id-token: write
 
+# Prevent PRs from trying to modify GCP resources concurrently
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     environment:


### PR DESCRIPTION
Deploying multiple PRs at the same time can cause errors since they operate on the same GCP resources.